### PR TITLE
Added missing System.Data.SqlClient dependency

### DIFF
--- a/src/Watchers/Warden.Watchers.MsSql/project.json
+++ b/src/Watchers/Warden.Watchers.MsSql/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.1",
   "description": "Warden watcher for MSSQL.",
   "authors": [ "Piotr Gankiewicz" ],
@@ -7,6 +7,7 @@
   "licenseUrl": "https://github.com/warden-stack/Warden/blob/master/LICENSE",
   "dependencies": {
     "Warden": "1.1",
+    "System.Data.SqlClient": "4.1.0",
     "Dapper": "1.42.0"
   },
   "frameworks": {


### PR DESCRIPTION
There were build errors due of lack "System.Data.SqlClient" dependency in Warden.Watchers.MsSql project.