### PR TITLE
Thrown exception reflected in WatcherCheckResult

### DIFF
--- a/src/Warden/Core/IIterationProcessor.cs
+++ b/src/Warden/Core/IIterationProcessor.cs
@@ -114,7 +114,7 @@ namespace Warden.Core
             {
                 _logger.Error($"There was an error while executing Watcher: {watcher.Name}.", exception);
                 var completedAt = _configuration.DateTimeProvider();
-                wardenCheckResult = WardenCheckResult.Create(WatcherCheckResult.Create(watcher, false),
+                wardenCheckResult = WardenCheckResult.Create(WatcherCheckResult.Create(watcher, false, exception.Message),
                     startedAt, completedAt, exception);
                 results.Add(new WatcherExecutionResult(watcher, WatcherResultState.Error,
                     GetPreviousWatcherState(watcher), wardenCheckResult, exception));


### PR DESCRIPTION
When an exception is throw the WatcherCheckResult will reflect this. For example a misconfigured SSL certificate on a web endpoint will throw an exception.