### PR TITLE
Slack integration can also send a colored message.

### DIFF
--- a/src/Integrations/Warden.Integrations.Slack/ISlackService.cs
+++ b/src/Integrations/Warden.Integrations.Slack/ISlackService.cs
@@ -22,6 +22,18 @@ namespace Warden.Integrations.Slack
         /// <returns></returns>
         Task SendMessageAsync(string message, string channel = null, string username = null, 
             TimeSpan? timeout = null, bool failFast = false);
+
+        /// <summary>
+        /// Executes the HTTP POST request.
+        /// </summary>
+        /// <param name="message">Message text.</param>
+        /// <param name="valid">Indicates if the message should display a positive or negative color</param>
+        /// <param name="channel">Optional name of channel to which the message will be sent.</param>
+        /// <param name="username">Optional username that will send the message.</param>
+        /// <param name="timeout">Optional timeout for the request.</param>
+        /// <param name="failFast">Optional flag determining whether an exception should be thrown if received reponse is invalid (false by default).</param>
+        Task SendColoredMessageAsync(string message, bool valid, string channel = null, string username = null,
+            TimeSpan? timeout = null, bool failFast = false);
     }
 
     /// <summary>
@@ -49,6 +61,47 @@ namespace Warden.Integrations.Slack
                     channel,
                     username,
                 };
+                var serializedPayload = JsonConvert.SerializeObject(payload);
+                var response = await _httpClient.PostAsync(_webhookUrl, new StringContent(
+                    serializedPayload, Encoding.UTF8, "application/json"));
+
+                if (response.IsSuccessStatusCode)
+                    return;
+                if (!failFast)
+                    return;
+
+                throw new IntegrationException("Received invalid HTTP response from Slack API " +
+                                               $"with status code: {response.StatusCode}. Reason phrase: {response.ReasonPhrase}");
+            }
+            catch (Exception exception)
+            {
+                if (!failFast)
+                    return;
+
+                throw new IntegrationException("There was an error while executing the SendMessageAsync(): " +
+                                               $"{exception}", exception);
+            }
+        }
+
+        public async Task SendColoredMessageAsync(string message, bool valid, string channel = null, string username = null,
+            TimeSpan? timeout = null, bool failFast = false)
+        {
+            SetTimeout(timeout);
+            try
+            {
+                var attachment = new
+                {
+                    fallback = message,
+                    color = valid ? "good" : "danger",
+                    fields = new [] { new { value = message } }
+                };
+                var payload = new
+                {
+                    channel,
+                    username,
+                    attachments = new[] {attachment} 
+                };
+
                 var serializedPayload = JsonConvert.SerializeObject(payload);
                 var response = await _httpClient.PostAsync(_webhookUrl, new StringContent(
                     serializedPayload, Encoding.UTF8, "application/json"));

--- a/src/Integrations/Warden.Integrations.Slack/SlackIntegration.cs
+++ b/src/Integrations/Warden.Integrations.Slack/SlackIntegration.cs
@@ -65,6 +65,43 @@ namespace Warden.Integrations.Slack
             await _slackService.SendMessageAsync(message, channel, username);
         }
 
+
+        /// <summary>
+        /// Sends a message to the default channel, using a default username.
+        /// </summary>
+        /// <param name="message">Message text. If default message has been set, it will override its value.</param>
+        /// <param name="isValid">Make the message have a good or bad identifier in Slack</param>
+        /// <returns></returns>
+        public async Task SendColoredMessageAsync(string message, bool isValid)
+        {
+            await SendColoredMessageAsync(message, isValid, _configuration.DefaultChannel, _configuration.DefaultUsername);
+        }
+
+        /// <summary>
+        /// Sends a message to the selected channel, using a default username.
+        /// </summary>
+        /// <param name="message">Message text. If default message has been set, it will override its value.</param>
+        /// <param name="isValid">Make the message have a good or bad identifier in Slack</param>
+        /// <param name="channel">Channel name. If default channel has been set, it will override its value.</param>
+        /// <returns></returns>
+        public async Task SendColoredMessageAsync(string message, bool isValid, string channel)
+        {
+            await SendColoredMessageAsync(message, isValid, channel, _configuration.DefaultUsername);
+        }
+
+        /// <summary>
+        /// Sends a message to the selected channel, using a given username.
+        /// </summary>
+        /// <param name="message">Message text. If default message has been set, it will override its value.</param>
+        /// <param name="isValid">Make the message have a good or bad identifier in Slack</param>
+        /// <param name="channel">Channel name. If default channel has been set, it will override its value.</param>
+        /// <param name="username">Custom username. If default username has been set, it will override its value.</param>
+        /// <returns></returns>
+        public async Task SendColoredMessageAsync(string message, bool isValid, string channel, string username)
+        {
+            await _slackService.SendColoredMessageAsync(message, isValid, channel, username);
+        }
+
         /// <summary>
         /// Factory method for creating a new instance of SlackIntegration.
         /// </summary>


### PR DESCRIPTION
Using the Slack attachments the messages towards Slack can now be colored, making it extra visible what the status of the check is.

Reference:
https://api.slack.com/docs/message-attachments