### PR TITLE
Close connection to Redis after watcher execution

### DIFF
--- a/src/Watchers/Warden.Watchers.Redis/IRedisConnection.cs
+++ b/src/Watchers/Warden.Watchers.Redis/IRedisConnection.cs
@@ -58,14 +58,12 @@ namespace Warden.Watchers.Redis
             return new Redis(database);
         }
 
-        public Task CloseConnectionAsync()
+        public async Task CloseConnectionAsync()
         {
-            if (_connectionMultiplexer.IsConnected)
+            if (_connectionMultiplexer != null && _connectionMultiplexer.IsConnected)
             {
-                return _connectionMultiplexer.CloseAsync();
+                await _connectionMultiplexer.CloseAsync();
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Watchers/Warden.Watchers.Redis/IRedisConnection.cs
+++ b/src/Watchers/Warden.Watchers.Redis/IRedisConnection.cs
@@ -22,6 +22,11 @@ namespace Warden.Watchers.Redis
         /// </summary>
         /// <returns>Instance of IRedis.</returns>
         Task<IRedis> GetDatabaseAsync(int database);
+
+        /// <summary>
+        /// Closes the connection to Redis
+        /// </summary>
+        Task CloseConnectionAsync();
     }
 
     /// <summary>
@@ -44,13 +49,23 @@ namespace Warden.Watchers.Redis
         {
             _connectionMultiplexer = await ConnectionMultiplexer.ConnectAsync(new ConfigurationOptions
             {
-                EndPoints = { ConnectionString},
+                EndPoints = { ConnectionString },
                 ConnectTimeout = (int)Timeout.TotalMilliseconds
             });
 
             var database = _connectionMultiplexer.GetDatabase(databaseId);
 
             return new Redis(database);
+        }
+
+        public Task CloseConnectionAsync()
+        {
+            if (_connectionMultiplexer.IsConnected)
+            {
+                return _connectionMultiplexer.CloseAsync();
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Watchers/Warden.Watchers.Redis/RedisWatcher.cs
+++ b/src/Watchers/Warden.Watchers.Redis/RedisWatcher.cs
@@ -45,7 +45,7 @@ namespace Warden.Watchers.Redis
                 if (string.IsNullOrWhiteSpace(_configuration.Query))
                 {
                     return RedisWatcherCheckResult.Create(this, true, _configuration.Database,
-                        _configuration.ConnectionString, 
+                        _configuration.ConnectionString,
                         $"Database: {_configuration.Database} has been sucessfully checked.");
                 }
 
@@ -59,6 +59,10 @@ namespace Warden.Watchers.Redis
             catch (Exception exception)
             {
                 throw new WatcherException("There was an error while trying to access the Redis.", exception);
+            }
+            finally
+            {
+                await _connection.CloseConnectionAsync();
             }
         }
 


### PR DESCRIPTION
I ran into Redis' max client connection limit after multiple iterations of the watcher not closing its connections properly.